### PR TITLE
added improved response info to Send Active/Trapper packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/adrianlzt/go-zabbix"
+	"github.com/datadope-io/go-zabbix"
 )
 
 const (
@@ -30,7 +30,13 @@ func main() {
 	z := zabbix.NewSender(defaultHost, defaultPort)
 	resActive, errActive, resTrapper, errTrapper := z.SendMetrics(metrics)
 
-	fmt.Printf("Agent active, response=%s, error=%v\n", resActive, errActive)
-	fmt.Printf("Trapper, response=%s, error=%v\n", resTrapper, errTrapper)
+	fmt.Printf("Agent active, response=%s, info=%s, error=%v\n", resActive.Response,resActive.Info, errActive)
+	fmt.Printf("Trapper, response=%s, info=%s,error=%v\n", resTrapper.Response, resTrapper.Info,errTrapper)
 }
 ```
+
+# CHANGELOG
+
+# 2020-10-20
+
+* Now Active/Trapper response is formated in Response,Info strings and could be translated int ResponseInfo struct with Failed/Completed/Processed/Spent time.

--- a/zabbix.go
+++ b/zabbix.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -54,6 +55,51 @@ type Packet struct {
 type Response struct {
 	Response string
 	Info     string
+}
+
+type ResponseInfo struct {
+	Processed int
+	Failed    int
+	Total     int
+	Spent     time.Duration
+}
+
+func (r *Response) GetInfo() (*ResponseInfo, error) {
+	ret := ResponseInfo{}
+	if r.Response != "success" {
+		return &ret, fmt.Errorf("Can not process info if response not Success (%s)", r.Response)
+	}
+
+	sp := strings.Split(r.Info, ";")
+	if len(sp) != 4 {
+		return &ret, fmt.Errorf("Error in splited data, expected 4 got %d for data (%s)", len(sp), r.Info)
+	}
+	for _, s := range sp {
+		sp2 := strings.Split(s, ":")
+		if len(sp2) != 2 {
+			return &ret, fmt.Errorf("Error in splited data, expected 2 got %d for data (%s)", len(sp2), s)
+		}
+		key := strings.TrimSpace(sp2[0])
+		value := strings.TrimSpace(sp2[1])
+		var err error
+		switch key {
+		case "processed":
+			ret.Processed, err = strconv.Atoi(value)
+		case "failed":
+			ret.Failed, err = strconv.Atoi(value)
+		case "total":
+			ret.Total, err = strconv.Atoi(value)
+		case "seconds spent":
+			var f float64
+			if f, err = strconv.ParseFloat(value, 64); err != nil {
+				return &ret, fmt.Errorf("Error in parsing seconds spent value [%s] error: %s", value, err)
+			}
+			ret.Spent = time.Duration(int64(f * 1000000000.0))
+		}
+
+	}
+
+	return &ret, nil
 }
 
 // NewPacket return a zabbix packet with a list of metrics
@@ -139,7 +185,7 @@ func (s *Sender) read(conn net.Conn) ([]byte, error) {
 // trapper and active items.
 // The response for trapper metrics is in the first element of the res array and err array
 // Response for active metrics is in the second element of the res array and error array
-func (s *Sender) SendMetrics(metrics []*Metric) (resActive []byte, errActive error, resTrapper []byte, errTrapper error) {
+func (s *Sender) SendMetrics(metrics []*Metric) (resActive Response, errActive error, resTrapper Response, errTrapper error) {
 	var trapperMetrics []*Metric
 	var activeMetrics []*Metric
 
@@ -152,6 +198,7 @@ func (s *Sender) SendMetrics(metrics []*Metric) (resActive []byte, errActive err
 	}
 
 	if len(trapperMetrics) > 0 {
+
 		packetTrapper := NewPacket(trapperMetrics, false)
 		resTrapper, errTrapper = s.Send(packetTrapper)
 	}
@@ -165,7 +212,7 @@ func (s *Sender) SendMetrics(metrics []*Metric) (resActive []byte, errActive err
 }
 
 // Send connects to Zabbix, send the data, return the response and close the connection
-func (s *Sender) Send(packet *Packet) (res []byte, err error) {
+func (s *Sender) Send(packet *Packet) (res Response, err error) {
 	// Timeout to resolve and connect to the server
 	conn, err := net.DialTimeout("tcp", s.Host+":"+strconv.Itoa(s.Port), s.ConnectTimeout)
 	if err != nil {
@@ -192,9 +239,20 @@ func (s *Sender) Send(packet *Packet) (res []byte, err error) {
 	conn.SetReadDeadline(time.Now().Add(s.ReadTimeout))
 
 	// Read response from server
-	res, err = s.read(conn)
+	response, err := s.read(conn)
 	if err != nil {
-		return res, fmt.Errorf("reading the response (timeout=%v): %s", s.ReadTimeout, err.Error())
+		return res, fmt.Errorf("reading the response (timeout=%v): %s", s.ReadTimeout, err)
+	}
+
+	header := response[:5]
+	data := response[13:]
+
+	if !bytes.Equal(header, s.getHeader()) {
+		return res, fmt.Errorf("got no valid header [%+v] , expected [%+v]", header, s.getHeader())
+	}
+
+	if err := json.Unmarshal(data, &res); err != nil {
+		return res, fmt.Errorf("zabbix response is not valid: %v", err)
 	}
 
 	return res, nil
@@ -210,20 +268,7 @@ func (s *Sender) RegisterHost(host, hostmetadata string) error {
 		return fmt.Errorf("sending packet: %v", err)
 	}
 
-	header := res[:4]
-	//length := res[4:13]
-	data := res[13:]
-
-	if bytes.Equal(header, s.getHeader()) {
-		return fmt.Errorf("response header is not valid")
-	}
-
-	response := Response{}
-	if err := json.Unmarshal(data, &response); err != nil {
-		fmt.Errorf("zabbix response is not valid: %v", err)
-	}
-
-	if response.Response == "success" {
+	if res.Response == "success" {
 		return nil
 	}
 
@@ -236,20 +281,7 @@ func (s *Sender) RegisterHost(host, hostmetadata string) error {
 		return fmt.Errorf("sending packet: %v", err)
 	}
 
-	header = res[:4]
-	//length := res[4:13]
-	data = res[13:]
-
-	if bytes.Equal(header, s.getHeader()) {
-		return fmt.Errorf("response header is not valid")
-	}
-
-	response = Response{}
-	if err = json.Unmarshal(data, &response); err != nil {
-		fmt.Errorf("zabbix response is not valid: %v", err)
-	}
-
-	if response.Response == "failed" {
+	if res.Response == "failed" {
 		return fmt.Errorf("autoregistration failed, verify hostmetadata")
 	}
 

--- a/zabbix_test.go
+++ b/zabbix_test.go
@@ -1,34 +1,339 @@
 package zabbix
 
 import (
+	"encoding/binary"
+	"encoding/json"
 	"fmt"
+	"net"
 	"testing"
 )
 
-func TestSendMetric(t *testing.T) {
-	m := NewMetric("zabbixAgent1", "active", "13", true)
-	m2 := NewMetric("zabbixAgent1", "trapper", "12", false)
-	s := NewSender("10.20.20.179", 10051)
-	resActive, errActive, resTrapper, errTrapper := s.SendMetrics([]*Metric{m, m2})
+type ZabbixRequestData struct {
+	Host  string `json:"host"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Clock int64  `json:"clock"`
+}
+
+type ZabbixRequest struct {
+	Request      string              `json:"request"`
+	Data         []ZabbixRequestData `json:"data"`
+	Clock        int                 `json:"clock"`
+	Host         string              `json:"host"`
+	HostMetadata string              `json:"host_metadata"`
+}
+
+func TestSendActiveMetric(t *testing.T) {
+	zabbixHost := "127.0.0.1"
+	zabbixPort := 10051
+
+	// Simulate a Zabbix server to get the data sent
+	listener, lerr := net.Listen("tcp", fmt.Sprintf("%v:%v", zabbixHost, zabbixPort))
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	defer listener.Close()
+
+	errs := make(chan error, 1)
+
+	go func(chan error) {
+		conn, err := listener.Accept()
+		if err != nil {
+			errs <- err
+		}
+
+		// Obtain request from the mock zabbix server
+		// Read protocol header and version
+		header := make([]byte, 5)
+		_, err = conn.Read(header)
+		if err != nil {
+			errs <- err
+		}
+
+		// Read data length
+		dataLengthRaw := make([]byte, 8)
+		_, err = conn.Read(dataLengthRaw)
+		if err != nil {
+			errs <- err
+		}
+
+		dataLength := binary.LittleEndian.Uint64(dataLengthRaw)
+
+		// Read data content
+		content := make([]byte, dataLength)
+		_, err = conn.Read(content)
+		if err != nil {
+			errs <- err
+		}
+
+		// The zabbix output checks that there are not errors
+		// Zabbix header length not used, set to 1
+		resp := []byte("ZBXD\x01\x00\x00\x00\x00\x00\x00\x00\x00{\"response\":\"success\",\"info\":\"processed: 1; failed: 0; total: 1; seconds spent: 0.000030\"}")
+		_, err = conn.Write(resp)
+		if err != nil {
+			errs <- err
+		}
+
+		// Close connection after reading the client data
+		conn.Close()
+
+		// Strip zabbix header and get JSON request
+		var request ZabbixRequest
+		err = json.Unmarshal(content, &request)
+		if err != nil {
+			errs <- err
+		}
+
+		expectedRequest := "agent data"
+		if expectedRequest != request.Request {
+			errs <- fmt.Errorf("Incorrect request field received, expected '%s'", expectedRequest)
+		}
+
+		// End zabbix fake backend
+		errs <- nil
+	}(errs)
+
+	m := NewMetric("zabbixAgent1", "ping", "13", true)
+
+	s := NewSender(zabbixHost, zabbixPort)
+	resActive, errActive, resTrapper, errTrapper := s.SendMetrics([]*Metric{m})
 	if errActive != nil {
-		t.Fatalf("error enviando la metrica Active: %v", errActive)
+		t.Fatalf("error sending active metric: %v", errActive)
 	}
 	if errTrapper != nil {
-		t.Fatalf("error enviando la metrica Trapper: %v", errTrapper)
+		t.Fatalf("trapper error should be nil, we are not sending trapper metrics: %v", errTrapper)
 	}
-	t.Logf("ACTIVE: %+v\n", resActive)
-	t.Logf("TRAPPER: %+v\n", resTrapper)
 
 	raInfo, err := resActive.GetInfo()
 	if err != nil {
 		t.Fatalf("error in response Trapper: %v", err)
 	}
 
-	if raInfo.Failed != 1 {
-		t.Errorf("Failed error expected 1 got %d", raInfo.Failed)
+	if raInfo.Failed != 0 {
+		t.Errorf("Failed error expected 0 got %d", raInfo.Failed)
 	}
-	if raInfo.Processed != 0 {
-		t.Errorf("Processed error expected 0 got %d", raInfo.Processed)
+	if raInfo.Processed != 1 {
+		t.Errorf("Processed error expected 1 got %d", raInfo.Processed)
+	}
+	if raInfo.Total != 1 {
+		t.Errorf("Total error expected 1 got %d", raInfo.Total)
+	}
+
+	_, err = resTrapper.GetInfo()
+	if err == nil {
+		t.Fatalf("No response trapper expected: %v", err)
+	}
+
+	// Wait for zabbix server emulator to finish
+	err = <-errs
+	if err != nil {
+		t.Fatalf("Fake zabbix backend should not produce any errors: %v", err)
+	}
+}
+
+func TestSendTrapperMetric(t *testing.T) {
+	zabbixHost := "127.0.0.1"
+	zabbixPort := 10051
+
+	// Simulate a Zabbix server to get the data sent
+	listener, lerr := net.Listen("tcp", fmt.Sprintf("%v:%v", zabbixHost, zabbixPort))
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	defer listener.Close()
+
+	errs := make(chan error, 1)
+
+	go func(chan error) {
+		conn, err := listener.Accept()
+		if err != nil {
+			errs <- err
+		}
+
+		// Obtain request from the mock zabbix server
+		// Read protocol header and version
+		header := make([]byte, 5)
+		_, err = conn.Read(header)
+		if err != nil {
+			errs <- err
+		}
+
+		// Read data length
+		dataLengthRaw := make([]byte, 8)
+		_, err = conn.Read(dataLengthRaw)
+		if err != nil {
+			errs <- err
+		}
+
+		dataLength := binary.LittleEndian.Uint64(dataLengthRaw)
+
+		// Read data content
+		content := make([]byte, dataLength)
+		_, err = conn.Read(content)
+		if err != nil {
+			errs <- err
+		}
+
+		// The zabbix output checks that there are not errors
+		resp := []byte("ZBXD\x01\x00\x00\x00\x00\x00\x00\x00\x00{\"response\":\"success\",\"info\":\"processed: 1; failed: 0; total: 1; seconds spent: 0.000030\"}")
+		_, err = conn.Write(resp)
+		if err != nil {
+			errs <- err
+		}
+
+		// Close connection after reading the client data
+		conn.Close()
+
+		// Strip zabbix header and get JSON request
+		var request ZabbixRequest
+		err = json.Unmarshal(content, &request)
+		if err != nil {
+			errs <- err
+		}
+
+		expectedRequest := "sender data"
+		if expectedRequest != request.Request {
+			errs <- fmt.Errorf("Incorrect request field received, expected '%s'", expectedRequest)
+		}
+
+		// End zabbix fake backend
+		errs <- nil
+	}(errs)
+
+	m := NewMetric("zabbixAgent1", "ping", "13", false)
+
+	s := NewSender(zabbixHost, zabbixPort)
+	resActive, errActive, resTrapper, errTrapper := s.SendMetrics([]*Metric{m})
+	if errTrapper != nil {
+		t.Fatalf("error sending trapper metric: %v", errTrapper)
+	}
+	if errActive != nil {
+		t.Fatalf("active error should be nil, we are not sending zabbix agent metrics: %v", errActive)
+	}
+
+	rtInfo, err := resTrapper.GetInfo()
+	if err != nil {
+		t.Fatalf("error in response Trapper: %v", err)
+	}
+
+	if rtInfo.Failed != 0 {
+		t.Errorf("Failed error expected 0 got %d", rtInfo.Failed)
+	}
+	if rtInfo.Processed != 1 {
+		t.Errorf("Processed error expected 1 got %d", rtInfo.Processed)
+	}
+	if rtInfo.Total != 1 {
+		t.Errorf("Total error expected 1 got %d", rtInfo.Total)
+	}
+
+	_, err = resActive.GetInfo()
+	if err == nil {
+		t.Fatalf("No response active expected: %v", err)
+	}
+
+	// Wait for zabbix server emulator to finish
+	err = <-errs
+	if err != nil {
+		t.Fatalf("Fake zabbix backend should not produce any errors: %v", err)
+	}
+}
+
+func TestSendActiveAndTrapperMetric(t *testing.T) {
+	zabbixHost := "127.0.0.1"
+	zabbixPort := 10051
+
+	// Simulate a Zabbix server to get the data sent
+	listener, lerr := net.Listen("tcp", fmt.Sprintf("%v:%v", zabbixHost, zabbixPort))
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	defer listener.Close()
+
+	errs := make(chan error, 1)
+
+	go func(chan error) {
+		for i := 0; i < 2; i++ {
+			conn, err := listener.Accept()
+			if err != nil {
+				errs <- err
+			}
+
+			// Obtain request from the mock zabbix server
+			// Read protocol header and version
+			header := make([]byte, 5)
+			_, err = conn.Read(header)
+			if err != nil {
+				errs <- err
+			}
+
+			// Read data length
+			dataLengthRaw := make([]byte, 8)
+			_, err = conn.Read(dataLengthRaw)
+			if err != nil {
+				errs <- err
+			}
+
+			dataLength := binary.LittleEndian.Uint64(dataLengthRaw)
+
+			// Read data content
+			content := make([]byte, dataLength)
+			_, err = conn.Read(content)
+			if err != nil {
+				errs <- err
+			}
+
+			// Strip zabbix header and get JSON request
+			var request ZabbixRequest
+			err = json.Unmarshal(content, &request)
+			if err != nil {
+				errs <- err
+			}
+
+			resp := []byte("")
+
+			if request.Request == "sender data" {
+				resp = []byte("ZBXD\x01\x00\x00\x00\x00\x00\x00\x00\x00{\"response\":\"success\",\"info\":\"processed: 1; failed: 0; total: 1; seconds spent: 0.000030\"}")
+			} else if request.Request == "agent data" {
+				resp = []byte("ZBXD\x01\x00\x00\x00\x00\x00\x00\x00\x00{\"response\":\"success\",\"info\":\"processed: 1; failed: 0; total: 1; seconds spent: 0.111111\"}")
+			}
+
+			// The zabbix output checks that there are not errors
+			_, err = conn.Write(resp)
+			if err != nil {
+				errs <- err
+			}
+
+			// Close connection after reading the client data
+			conn.Close()
+		}
+
+		// End zabbix fake backend
+		errs <- nil
+	}(errs)
+
+	m := NewMetric("zabbixAgent1", "ping", "13", true)
+	m2 := NewMetric("zabbixTrapper1", "pong", "13", false)
+
+	s := NewSender(zabbixHost, zabbixPort)
+	resActive, errActive, resTrapper, errTrapper := s.SendMetrics([]*Metric{m, m2})
+
+	if errActive != nil {
+		t.Fatalf("error sending active metric: %v", errActive)
+	}
+	if errTrapper != nil {
+		t.Fatalf("error sending trapper metric: %v", errTrapper)
+	}
+
+	raInfo, err := resActive.GetInfo()
+	if err != nil {
+		t.Fatalf("error in response Trapper: %v", err)
+	}
+
+	if raInfo.Failed != 0 {
+		t.Errorf("Failed error expected 0 got %d", raInfo.Failed)
+	}
+	if raInfo.Processed != 1 {
+		t.Errorf("Processed error expected 1 got %d", raInfo.Processed)
 	}
 	if raInfo.Total != 1 {
 		t.Errorf("Total error expected 1 got %d", raInfo.Total)
@@ -39,44 +344,278 @@ func TestSendMetric(t *testing.T) {
 		t.Fatalf("error in response Trapper: %v", err)
 	}
 
-	if rtInfo.Failed != 1 {
-		t.Errorf("Failed error expected 1 got %d", rtInfo.Failed)
+	if rtInfo.Failed != 0 {
+		t.Errorf("Failed error expected 0 got %d", rtInfo.Failed)
 	}
-	if rtInfo.Processed != 0 {
-		t.Errorf("Processed error expected 0 got %d", rtInfo.Processed)
+	if rtInfo.Processed != 1 {
+		t.Errorf("Processed error expected 1 got %d", rtInfo.Processed)
 	}
 	if rtInfo.Total != 1 {
 		t.Errorf("Total error expected 1 got %d", rtInfo.Total)
 	}
 
+	// Wait for zabbix server emulator to finish
+	err = <-errs
+	if err != nil {
+		t.Fatalf("Fake zabbix backend should not produce any errors: %v", err)
+	}
 }
 
-func ExampleSendMetric() {
-	m := NewMetric("zabbixAgent1", "active", "13", true)
-	m2 := NewMetric("zabbixAgent1", "trapper", "12", false)
-	s := NewSender("10.20.20.179", 10051)
-	resActive, errActive, resTrapper, errTrapper := s.SendMetrics([]*Metric{m, m2})
-	if errActive != nil {
-		fmt.Errorf("error enviando la metrica Active: %v", errActive)
-		return
+func TestRegisterHostOK(t *testing.T) {
+	zabbixHost := "127.0.0.1"
+	zabbixPort := 10051
+
+	// Simulate a Zabbix server to get the data sent
+	listener, lerr := net.Listen("tcp", fmt.Sprintf("%v:%v", zabbixHost, zabbixPort))
+	if lerr != nil {
+		t.Fatal(lerr)
 	}
-	if errTrapper != nil {
-		fmt.Errorf("error enviando la metrica Trapper: %v", errTrapper)
-		return
-	}
-	iA, err := resActive.GetInfo()
+	defer listener.Close()
+
+	errs := make(chan error, 1)
+
+	go func(chan error) {
+		for i := 0; i < 2; i++ {
+			conn, err := listener.Accept()
+			if err != nil {
+				errs <- err
+			}
+
+			// Obtain request from the mock zabbix server
+			// Read protocol header and version
+			header := make([]byte, 5)
+			_, err = conn.Read(header)
+			if err != nil {
+				errs <- err
+			}
+
+			// Read data length
+			dataLengthRaw := make([]byte, 8)
+			_, err = conn.Read(dataLengthRaw)
+			if err != nil {
+				errs <- err
+			}
+
+			dataLength := binary.LittleEndian.Uint64(dataLengthRaw)
+
+			// Read data content
+			content := make([]byte, dataLength)
+			_, err = conn.Read(content)
+			if err != nil {
+				errs <- err
+			}
+
+			// Strip zabbix header and get JSON request
+			var request ZabbixRequest
+			err = json.Unmarshal(content, &request)
+			if err != nil {
+				errs <- err
+			}
+
+			expectedRequest := "active checks"
+			if expectedRequest != request.Request {
+				errs <- fmt.Errorf("Incorrect request field received, expected '%s'", expectedRequest)
+			}
+
+			// If the host does not exist, the first response will be an error
+			resp := []byte("ZBXD\x01\x00\x00\x00\x00\x00\x00\x00\x00{\"response\":\"failed\",\"info\": \"host [prueba] not found\"}")
+
+			// Next response is the valid one
+			if i == 1 {
+				resp = []byte("ZBXD\x01\x00\x00\x00\x00\x00\x00\x00\x00{\"response\":\"success\",\"data\": [{\"key\":\"net.if.in[eth0]\",\"delay\":60,\"lastlogsize\":0,\"mtime\":0}]}")
+			}
+
+			_, err = conn.Write(resp)
+			if err != nil {
+				errs <- err
+			}
+
+			// Close connection after reading the client data
+			conn.Close()
+		}
+
+		// End zabbix fake backend
+		errs <- nil
+	}(errs)
+
+	s := NewSender(zabbixHost, zabbixPort)
+	err := s.RegisterHost("prueba", "prueba")
 	if err != nil {
-		fmt.Errorf("error en respuesta Active: %s", err)
-		return
+		t.Fatalf("register host error: %v", err)
 	}
-	iT, err := resTrapper.GetInfo()
+
+	// Wait for zabbix server emulator to finish
+	err = <-errs
 	if err != nil {
-		fmt.Errorf("error en respuesta Trapper: %s", err)
-		return
+		t.Fatalf("Fake zabbix backend should not produce any errors: %v", err)
 	}
-	fmt.Printf("ACTIVE: %+v\n", iA.Failed)
-	fmt.Printf("TRAPPER: %+v\n", iT.Failed)
-	// Output:
-	//ACTIVE: 1
-	//TRAPPER: 1
+}
+
+func TestRegisterHostError(t *testing.T) {
+	zabbixHost := "127.0.0.1"
+	zabbixPort := 10051
+
+	// Simulate a Zabbix server to get the data sent
+	listener, lerr := net.Listen("tcp", fmt.Sprintf("%v:%v", zabbixHost, zabbixPort))
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	defer listener.Close()
+
+	errs := make(chan error, 1)
+
+	go func(chan error) {
+		for i := 0; i < 2; i++ {
+			conn, err := listener.Accept()
+			if err != nil {
+				errs <- err
+			}
+
+			// Obtain request from the mock zabbix server
+			// Read protocol header and version
+			header := make([]byte, 5)
+			_, err = conn.Read(header)
+			if err != nil {
+				errs <- err
+			}
+
+			// Read data length
+			dataLengthRaw := make([]byte, 8)
+			_, err = conn.Read(dataLengthRaw)
+			if err != nil {
+				errs <- err
+			}
+
+			dataLength := binary.LittleEndian.Uint64(dataLengthRaw)
+
+			// Read data content
+			content := make([]byte, dataLength)
+			_, err = conn.Read(content)
+			if err != nil {
+				errs <- err
+			}
+
+			// Strip zabbix header and get JSON request
+			var request ZabbixRequest
+			err = json.Unmarshal(content, &request)
+			if err != nil {
+				errs <- err
+			}
+
+			expectedRequest := "active checks"
+			if expectedRequest != request.Request {
+				errs <- fmt.Errorf("Incorrect request field received, expected '%s'", expectedRequest)
+			}
+
+			// Simulate error always
+			resp := []byte("ZBXD\x01\x00\x00\x00\x00\x00\x00\x00\x00{\"response\":\"failed\",\"info\": \"host [prueba] not found\"}")
+			_, err = conn.Write(resp)
+			if err != nil {
+				errs <- err
+			}
+
+			// Close connection after reading the client data
+			conn.Close()
+		}
+
+		// End zabbix fake backend
+		errs <- nil
+	}(errs)
+
+	s := NewSender(zabbixHost, zabbixPort)
+	err := s.RegisterHost("prueba", "prueba")
+	if err == nil {
+		t.Fatalf("should return an error: %v", err)
+	}
+
+	// Wait for zabbix server emulator to finish
+	err = <-errs
+	if err != nil {
+		t.Fatalf("Fake zabbix backend should not produce any errors: %v", err)
+	}
+}
+
+func TestInvalidResponseHeader(t *testing.T) {
+	zabbixHost := "127.0.0.1"
+	zabbixPort := 10051
+
+	// Simulate a Zabbix server to get the data sent
+	listener, lerr := net.Listen("tcp", fmt.Sprintf("%v:%v", zabbixHost, zabbixPort))
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	defer listener.Close()
+
+	errs := make(chan error, 1)
+
+	go func(chan error) {
+		conn, err := listener.Accept()
+		if err != nil {
+			errs <- err
+		}
+
+		// Obtain request from the mock zabbix server
+		// Read protocol header and version
+		header := make([]byte, 5)
+		_, err = conn.Read(header)
+		if err != nil {
+			errs <- err
+		}
+
+		// Read data length
+		dataLengthRaw := make([]byte, 8)
+		_, err = conn.Read(dataLengthRaw)
+		if err != nil {
+			errs <- err
+		}
+
+		dataLength := binary.LittleEndian.Uint64(dataLengthRaw)
+
+		// Read data content
+		content := make([]byte, dataLength)
+		_, err = conn.Read(content)
+		if err != nil {
+			errs <- err
+		}
+
+		// The zabbix output checks that there are not errors
+		// Zabbix header length not used, set to 1
+		resp := []byte("BXD\x01\x00\x00\x00\x00\x00\x00\x00\x00{\"response\":\"success\",\"info\":\"processed: 1; failed: 0; total: 1; seconds spent: 0.000030\"}")
+		_, err = conn.Write(resp)
+		if err != nil {
+			errs <- err
+		}
+
+		// Close connection after reading the client data
+		conn.Close()
+
+		// Strip zabbix header and get JSON request
+		var request ZabbixRequest
+		err = json.Unmarshal(content, &request)
+		if err != nil {
+			errs <- err
+		}
+
+		expectedRequest := "agent data"
+		if expectedRequest != request.Request {
+			errs <- fmt.Errorf("Incorrect request field received, expected '%s'", expectedRequest)
+		}
+
+		// End zabbix fake backend
+		errs <- nil
+	}(errs)
+
+	m := NewMetric("zabbixAgent1", "ping", "13", true)
+
+	s := NewSender(zabbixHost, zabbixPort)
+	_, errActive, _, _ := s.SendMetrics([]*Metric{m})
+	if errActive == nil {
+		t.Fatal("Expected an error because an incorrect Zabbix protocol header")
+	}
+
+	// Wait for zabbix server emulator to finish
+	err := <-errs
+	if err != nil {
+		t.Fatalf("Fake zabbix backend should not produce any errors: %v", err)
+	}
 }

--- a/zabbix_test.go
+++ b/zabbix_test.go
@@ -8,11 +8,75 @@ import (
 func TestSendMetric(t *testing.T) {
 	m := NewMetric("zabbixAgent1", "active", "13", true)
 	m2 := NewMetric("zabbixAgent1", "trapper", "12", false)
-	s := NewSender("172.17.0.3", 10051)
-	res, err := s.SendMetrics([]*Metric{m, m2})
-	if err[0] != nil || err[1] != nil {
-		t.Fatalf("erroe enviando la metrica: %v", err)
+	s := NewSender("10.20.20.179", 10051)
+	resActive, errActive, resTrapper, errTrapper := s.SendMetrics([]*Metric{m, m2})
+	if errActive != nil {
+		t.Fatalf("error enviando la metrica Active: %v", errActive)
 	}
-	fmt.Println("trapper:", string(res[0]))
-	fmt.Println("active:", string(res[1]))
+	if errTrapper != nil {
+		t.Fatalf("error enviando la metrica Trapper: %v", errTrapper)
+	}
+	t.Logf("ACTIVE: %+v\n", resActive)
+	t.Logf("TRAPPER: %+v\n", resTrapper)
+
+	raInfo, err := resActive.GetInfo()
+	if err != nil {
+		t.Fatalf("error in response Trapper: %v", err)
+	}
+
+	if raInfo.Failed != 1 {
+		t.Errorf("Failed error expected 1 got %d", raInfo.Failed)
+	}
+	if raInfo.Processed != 0 {
+		t.Errorf("Processed error expected 0 got %d", raInfo.Processed)
+	}
+	if raInfo.Total != 1 {
+		t.Errorf("Total error expected 1 got %d", raInfo.Total)
+	}
+
+	rtInfo, err := resTrapper.GetInfo()
+	if err != nil {
+		t.Fatalf("error in response Trapper: %v", err)
+	}
+
+	if rtInfo.Failed != 1 {
+		t.Errorf("Failed error expected 1 got %d", rtInfo.Failed)
+	}
+	if rtInfo.Processed != 0 {
+		t.Errorf("Processed error expected 0 got %d", rtInfo.Processed)
+	}
+	if rtInfo.Total != 1 {
+		t.Errorf("Total error expected 1 got %d", rtInfo.Total)
+	}
+
+}
+
+func ExampleSendMetric() {
+	m := NewMetric("zabbixAgent1", "active", "13", true)
+	m2 := NewMetric("zabbixAgent1", "trapper", "12", false)
+	s := NewSender("10.20.20.179", 10051)
+	resActive, errActive, resTrapper, errTrapper := s.SendMetrics([]*Metric{m, m2})
+	if errActive != nil {
+		fmt.Errorf("error enviando la metrica Active: %v", errActive)
+		return
+	}
+	if errTrapper != nil {
+		fmt.Errorf("error enviando la metrica Trapper: %v", errTrapper)
+		return
+	}
+	iA, err := resActive.GetInfo()
+	if err != nil {
+		fmt.Errorf("error en respuesta Active: %s", err)
+		return
+	}
+	iT, err := resTrapper.GetInfo()
+	if err != nil {
+		fmt.Errorf("error en respuesta Trapper: %s", err)
+		return
+	}
+	fmt.Printf("ACTIVE: %+v\n", iA.Failed)
+	fmt.Printf("TRAPPER: %+v\n", iT.Failed)
+	// Output:
+	//ACTIVE: 1
+	//TRAPPER: 1
 }


### PR DESCRIPTION
Added parsed Response/Info data to the Metric Send() response. Enables check easily if metric/trapper has been properly sent or not